### PR TITLE
Improve trend filters with dropdown defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project fetches "Trending Now" topics from Google Trends and provides a minimal React interface to filter and download data.
 
+By default the UI starts with `HK` as the location, `en` as the language and a 24 hour time range. Only location and language are required; all other filters are optional and omitted from requests when left blank.
+
 ## Requirements
 
 - Python 3.10+

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -4,12 +4,14 @@ from pydantic import BaseModel
 class TrendRequest(BaseModel):
     """Parameters accepted by the trends API."""
 
-    geo: Optional[str] = "US"
-    hl: Optional[str] = "en"
-    hours: Optional[int] = 24
+    # Location and language are required with defaults matching Google Trends UI
+    geo: str = "HK"
+    hl: str = "en"
+    # Optional filters. None values will be omitted from the generated URL
+    hours: Optional[int] = None
     category: Optional[str] = None
     sort: Optional[str] = None
-    status: Optional[str] = "now"
+    status: Optional[str] = None
 
 class Trend(BaseModel):
     """Single trending topic."""

--- a/src/backend/parser.py
+++ b/src/backend/parser.py
@@ -1,10 +1,13 @@
 from bs4 import BeautifulSoup
 from typing import List
+
 from .models import Trend
 
 
 def parse_trending_html(html: str) -> List[Trend]:
     """Parse Google Trends HTML into a list of Trend objects."""
     soup = BeautifulSoup(html, "html.parser")
-    titles = [span.get_text(strip=True) for span in soup.select("span.title")]
+    # Titles appear within a td with class 'jvkLtd' in a div.mZ3RIc
+    title_nodes = soup.select("td.jvkLtd div.mZ3RIc")
+    titles = [node.get_text(strip=True) for node in title_nodes]
     return [Trend(title=t) for t in titles]

--- a/src/frontend/components/FilterPanel.tsx
+++ b/src/frontend/components/FilterPanel.tsx
@@ -7,16 +7,109 @@ interface Props {
 }
 
 export const FilterPanel: React.FC<Props> = ({ params, onChange }) => {
-  const handleInput = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-    onChange({ ...params, [e.target.name]: e.target.value });
+  const handleInput = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    let parsed: string | number | undefined = value === '' ? undefined : value;
+    if (name === 'hours' && parsed !== undefined) {
+      parsed = parseInt(parsed as string, 10);
+    }
+    onChange({ ...params, [name]: parsed });
   };
+
+  const categories = Array.from({ length: 83 }, (_, i) => (i + 1).toString());
+  const hoursOptions = ['1', '4', '8', '24', '72'];
+  const locations = ['HK', 'US', 'GB', 'JP'];
+  const languages = ['en', 'zh', 'es'];
 
   return (
     <div className="space-y-2 p-4 bg-gray-100 rounded">
-      <input name="geo" placeholder="Location" value={params.geo || ''} onChange={handleInput} className="border p-1" />
-      <input name="hl" placeholder="Language" value={params.hl || ''} onChange={handleInput} className="border p-1" />
-      <input name="hours" type="number" placeholder="Hours" value={params.hours || ''} onChange={handleInput} className="border p-1" />
-      <input name="category" placeholder="Category" value={params.category || ''} onChange={handleInput} className="border p-1" />
+      <label className="block">
+        <span className="mr-2">Location</span>
+        <select
+          name="geo"
+          value={params.geo}
+          onChange={handleInput}
+          className="border p-1"
+        >
+          {locations.map((loc) => (
+            <option key={loc} value={loc}>
+              {loc}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="block">
+        <span className="mr-2">Language</span>
+        <select
+          name="hl"
+          value={params.hl}
+          onChange={handleInput}
+          className="border p-1"
+        >
+          {languages.map((lang) => (
+            <option key={lang} value={lang}>
+              {lang}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="block">
+        <span className="mr-2">Hours</span>
+        <select
+          name="hours"
+          value={params.hours ?? ''}
+          onChange={handleInput}
+          className="border p-1"
+        >
+          <option value="">All</option>
+          {hoursOptions.map((h) => (
+            <option key={h} value={h}>
+              {h}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="block">
+        <span className="mr-2">Category</span>
+        <select
+          name="category"
+          value={params.category ?? ''}
+          onChange={handleInput}
+          className="border p-1"
+        >
+          <option value="">All</option>
+          {categories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="block">
+        <span className="mr-2">Sort</span>
+        <select
+          name="sort"
+          value={params.sort ?? ''}
+          onChange={handleInput}
+          className="border p-1"
+        >
+          <option value="">Default</option>
+          <option value="title">Title</option>
+          <option value="search-volume">Search volume</option>
+        </select>
+      </label>
+      <label className="block">
+        <span className="mr-2">Status</span>
+        <select
+          name="status"
+          value={params.status ?? ''}
+          onChange={handleInput}
+          className="border p-1"
+        >
+          <option value="">All</option>
+          <option value="active">Active</option>
+        </select>
+      </label>
     </div>
   );
 };

--- a/src/frontend/next.config.js
+++ b/src/frontend/next.config.js
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'http://localhost:8000/api/:path*', // Proxy to backend
+      },
+    ];
+  },
+};
+
+module.exports = nextConfig;

--- a/src/frontend/pages/index.tsx
+++ b/src/frontend/pages/index.tsx
@@ -3,7 +3,7 @@ import { FilterPanel } from '../components/FilterPanel';
 import { fetchTrends, TrendRequest, Trend } from '../utils/api';
 
 const Home: React.FC = () => {
-  const [params, setParams] = useState<TrendRequest>({ geo: 'US', hl: 'en', hours: 24 });
+  const [params, setParams] = useState<TrendRequest>({ geo: 'HK', hl: 'en', hours: 24 });
   const [topics, setTopics] = useState<Trend[]>([]);
 
   useEffect(() => {

--- a/src/frontend/utils/api.ts
+++ b/src/frontend/utils/api.ts
@@ -17,7 +17,12 @@ export interface TrendsResponse {
 }
 
 export async function fetchTrends(params: TrendRequest): Promise<TrendsResponse> {
-  const query = new URLSearchParams(params as Record<string, string>);
+  const query = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== '') {
+      query.append(key, String(value));
+    }
+  });
   const res = await fetch(`/api/trends?${query.toString()}`);
   if (!res.ok) throw new Error('Failed to fetch');
   return res.json();

--- a/src/frontend/utils/api.ts
+++ b/src/frontend/utils/api.ts
@@ -23,7 +23,9 @@ export async function fetchTrends(params: TrendRequest): Promise<TrendsResponse>
       query.append(key, String(value));
     }
   });
-  const res = await fetch(`/api/trends?${query.toString()}`);
+  // Call local backend API instead of Google Trends directly to avoid CORS
+  const url = `/api/trends?${query.toString()}`;
+  const res = await fetch(url);
   if (!res.ok) throw new Error('Failed to fetch');
   return res.json();
 }

--- a/tests/backend/test_parser.py
+++ b/tests/backend/test_parser.py
@@ -1,10 +1,10 @@
 from src.backend.parser import parse_trending_html
 
 SAMPLE_HTML = """
-<html><body>
-<span class='title'>Topic 1</span>
-<span class='title'>Topic 2</span>
-</body></html>
+<table><tbody>
+<tr jsname='oKdM2c'><td class='jvkLtd'><div class='mZ3RIc'>Topic 1</div></td></tr>
+<tr jsname='oKdM2c'><td class='jvkLtd'><div class='mZ3RIc'>Topic 2</div></td></tr>
+</tbody></table>
 """
 
 

--- a/tests/backend/test_url_builder.py
+++ b/tests/backend/test_url_builder.py
@@ -8,3 +8,10 @@ def test_build_trends_url_basic():
     assert "geo=HK" in url
     assert "hours=48" in url
     assert url.startswith("https://trends.google.com/trending?")
+
+
+def test_optional_params_omitted():
+    params = TrendRequest(geo="HK", hl="en")
+    url = build_trends_url(params)
+    assert "hours=" not in url
+    assert "category=" not in url

--- a/tests/frontend/test_placeholder.test.ts
+++ b/tests/frontend/test_placeholder.test.ts
@@ -3,8 +3,8 @@ import React from 'react';
 import { FilterPanel } from '../../src/frontend/components/FilterPanel';
 
 test('renders filter panel', () => {
-  const { getByPlaceholderText } = render(
-    <FilterPanel params={{}} onChange={() => {}} />
+  const { getByLabelText } = render(
+    <FilterPanel params={{ geo: 'HK', hl: 'en' }} onChange={() => {}} />
   );
-  expect(getByPlaceholderText('Location')).toBeInTheDocument();
+  expect(getByLabelText('Location')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- require location and language in API models and default to HK
- filter optional parameters from API requests
- add dropdown filter panel with category, sort, status options
- set HK defaults in homepage
- document default parameters
- ensure URL builder omits unset fields
- update frontend tests

## Testing
- `pip install -r requirements.txt`
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_b_686645b5a624832996afd7800474d73a